### PR TITLE
adicionado campo VAZIO nos ENUMs

### DIFF
--- a/src/main/java/br/com/gcm/sac/setor_armamento/enuns/CaliberEnum.java
+++ b/src/main/java/br/com/gcm/sac/setor_armamento/enuns/CaliberEnum.java
@@ -3,5 +3,6 @@ package br.com.gcm.sac.setor_armamento.enuns;
 public enum CaliberEnum {
     NOVE_MM,
     DOZE,
-    TREZENTOS_OITENTA
+    TREZENTOS_OITENTA,
+    VAZIO // opção para representar "vazio" ou nulo
 }

--- a/src/main/java/br/com/gcm/sac/setor_armamento/enuns/GenderEnum.java
+++ b/src/main/java/br/com/gcm/sac/setor_armamento/enuns/GenderEnum.java
@@ -2,5 +2,6 @@ package br.com.gcm.sac.setor_armamento.enuns;
 
 public enum GenderEnum {
     MASCULINO,
-    FEMININO
+    FEMININO,
+    VAZIO // opção para representar "vazio" ou nulo
 }

--- a/src/main/java/br/com/gcm/sac/setor_armamento/enuns/LevelProtectionEnum.java
+++ b/src/main/java/br/com/gcm/sac/setor_armamento/enuns/LevelProtectionEnum.java
@@ -3,5 +3,6 @@ package br.com.gcm.sac.setor_armamento.enuns;
 public enum LevelProtectionEnum {
     IIA,
     II,
-    IIIA
+    IIIA,
+    VAZIO // opção para representar "vazio" ou nulo
 }

--- a/src/main/java/br/com/gcm/sac/setor_armamento/enuns/RoleEnum.java
+++ b/src/main/java/br/com/gcm/sac/setor_armamento/enuns/RoleEnum.java
@@ -2,5 +2,5 @@ package br.com.gcm.sac.setor_armamento.enuns;
 
 public enum RoleEnum {
     ROLE_ADMIN,
-    ROLE_USER;    
+    ROLE_USER   
 }

--- a/src/main/java/br/com/gcm/sac/setor_armamento/enuns/SizeEnum.java
+++ b/src/main/java/br/com/gcm/sac/setor_armamento/enuns/SizeEnum.java
@@ -6,5 +6,6 @@ public enum SizeEnum {
     M,
     G,
     GG,
-    EXGG
+    EXGG,
+    VAZIO // opção para representar "vazio" ou nulo
 }

--- a/src/main/java/br/com/gcm/sac/setor_armamento/enuns/WearEnum.java
+++ b/src/main/java/br/com/gcm/sac/setor_armamento/enuns/WearEnum.java
@@ -2,5 +2,6 @@ package br.com.gcm.sac.setor_armamento.enuns;
 
 public enum WearEnum {
     OSTENSIVO,
-    VELADO
+    VELADO,
+    VAZIO // opção para representar "vazio" ou nulo
 }

--- a/src/main/java/br/com/gcm/sac/setor_armamento/service/UserService.java
+++ b/src/main/java/br/com/gcm/sac/setor_armamento/service/UserService.java
@@ -16,11 +16,6 @@ public class UserService implements UserDetailsService{
     
     @Autowired
     UserRepository userRepository;
-
-    // public UserModel save(UserModel user) throws NoSuchAlgorithmException{
-    //     user.setPassword(HashMD5.md5(user.getPassword()));
-    //     return userRepository.save(user);
-    // }
     
     public UserModel save(UserModel user){
         user.setPassword(new BCryptPasswordEncoder().encode(user.getPassword()));


### PR DESCRIPTION
O campo VAZIO nos ENUMs serve para receber do frontend os atributosque não são relacionados aos objetos instanciados